### PR TITLE
feat: se agrega la librería normalize.css para estilos globales

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -41,7 +41,8 @@
               "src/styles.scss",
               "node_modules/bootstrap-icons/font/bootstrap-icons.scss",
               "node_modules/primeng/resources/themes/lara-dark-purple/theme.css",
-              "node_modules/primeng/resources/primeng.min.css"
+              "node_modules/primeng/resources/primeng.min.css",
+              "node_modules/normalize.css/normalize.css"
             ],
             "scripts": []
           },
@@ -115,7 +116,8 @@
               "src/styles.scss",
               "node_modules/bootstrap-icons/font/bootstrap-icons.scss",
               "node_modules/primeng/resources/themes/lara-dark-purple/theme.css",
-              "node_modules/primeng/resources/primeng.min.css"
+              "node_modules/primeng/resources/primeng.min.css",
+              "node_modules/normalize.css/normalize.css"
             ],
             "scripts": []
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/platform-browser-dynamic": "^15.1.0",
         "@angular/router": "^15.1.0",
         "bootstrap-icons": "^1.10.3",
+        "normalize.css": "^8.0.1",
         "primeng": "^15.2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -8077,6 +8078,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "node_modules/npm-bundled": {
       "version": "3.0.0",
@@ -17130,6 +17136,11 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true
+    },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "npm-bundled": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser-dynamic": "^15.1.0",
     "@angular/router": "^15.1.0",
     "bootstrap-icons": "^1.10.3",
+    "normalize.css": "^8.0.1",
     "primeng": "^15.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
# Se agrega la librería normalice.css
El objetivo de agregar esta librería es agregar estilos globales para ajustar etiquetas según el navegador. Esta librería no produce un aumento significativo en el `bundle size`, y además al haber sido agregada mediante `npm` se podrá actualizar en caso de ser necesario