### PR TITLE
fix: se corrige error en 'publish_dir' de github-actions para deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,5 +38,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.ACCESS_TOKEN }}
-          publish_dir: dist/practice-version-15.2.4
+          publish_dir: dist/hararec-portfolio
           enable_jekyll: true


### PR DESCRIPTION
# Se corrige error en Github-actions
Se corrige el error de referencia en `publish_dir` de github-actions para el deploy del sitio web