### PR TITLE
Hotfix/correct images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [Documentación en español](#espanol) | [Documentation in English](#english)
 
-# <div id="espanol">💻 Sitio web personal v1.0.4 - HararecMG</div>
+# <div id="espanol">💻 Sitio web personal v1.0.5 - HararecMG</div>
 
 ## <div id="indice">📋 Índice</div>
 
@@ -198,7 +198,7 @@ Espero que hayas disfrutado explorando mis proyectos y que hayas encontrado algo
 <hr/>
 
 
-# <div id="english">💻 Personal website v1.0.4 - HararecMG</div>
+# <div id="english">💻 Personal website v1.0.5 - HararecMG</div>
 
 ## <div id="index">📋 Index</div>
 

--- a/angular.json
+++ b/angular.json
@@ -27,8 +27,6 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
-              "src/assets/i18n",
-              "src/assets/icons",
               "src/manifest.json",
               "src/humans.txt"
             ],
@@ -105,8 +103,6 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
-              "src/assets/i18n",
-              "src/assets/icons",
               "src/manifest.json",
               "src/humans.txt"
             ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hararec-portfolio",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hararec-portfolio",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@angular/animations": "^15.2.1",
         "@angular/cdk": "^15.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hararec-portfolio",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
# Se elimina carpeta `assets` en producción
Se elimina la carpeta `assets` de producción medinate la configuración de `assets` en `angular.json`, pues al crearse el build de producción en un flujo de trabajo de `github-actions`, se llamarán los archivos estáticos necesarios bajo demanda